### PR TITLE
Set app public by default

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -57,7 +57,7 @@
                     "fr": "Est-ce que cette application doit être visible publiquement ?"
                 },
                 "choices": ["Yes", "No"],
-                "default": "No"
+                "default": "Yes"
             },
             {
                 "name": "default_lang",


### PR DESCRIPTION
A website/blog is mainly used public.